### PR TITLE
Add GitHub release workflow for steam workshop

### DIFF
--- a/.github/workflows/workshop-release.yml
+++ b/.github/workflows/workshop-release.yml
@@ -21,4 +21,4 @@ jobs:
       with:
         artifacts: "workshop-release.zip"
         draft: true
-        body: "Test release"
+        body: "**Release draft. Generate release notes within the GH release edit form!**"


### PR DESCRIPTION
Whenever a tag is pushed onto the remote repo, a release draft is generated and all the necessary assets to be uploaded onto the steam workshop.
The release notes can be generated within the release edit form, before finalising the release.