### PR TITLE
Exclude `.vscode` from the build workflow

### DIFF
--- a/.github/workflows/workshop-release.yml
+++ b/.github/workflows/workshop-release.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         type: 'zip'
         filename: 'workshop-release.zip'
-        exclusions: '*.git* *.exe'
+        exclusions: '*.git* *.exe *.vscode*'
     - name: Upload release
       uses: ncipollo/release-action@main
       with:


### PR DESCRIPTION
Please test this with a branch that contains the `.vscode` folder in the repository root.
Don't merge before it has been tested!