### PR TITLE
Fix drop container persisting the burn time for burning drops

### DIFF
--- a/Scripts/Drops/Drop.lua
+++ b/Scripts/Drops/Drop.lua
@@ -69,9 +69,7 @@ function Drop:server_onFixedUpdate()
 	if publicData then
 		--burning
 		if publicData.burnTime then
-			publicData.burnTime = publicData.burnTime - 1
-
-			if publicData.burnTime <= 0 then
+			if sm.game.getCurrentTick() >= publicData.burnTime then --NOTE this might be an issue when saving the game and loading in
 				PollutionManager.sv_addPollution(publicData.value)
 				sm.event.sendToPlayer(sm.player.getAllPlayers()[1], "sv_e_numberEffect", {
 					pos = self.shape.worldPosition,
@@ -284,6 +282,7 @@ end
 ---@class clientData
 ---@field pollution number
 ---@field value number
+---@field burnTime number the tick where it will burn
 
 ---@class DropInteractable : Interactable
 ---@field publicData DropInteractablePublicData
@@ -296,7 +295,9 @@ end
 ---@field pollution number|nil if the drop is polluted and by how much. Effective pollution is `pollution - value`
 ---@field tractorBeam integer|nil if the drop is currently inside a tractorBeam
 ---@field magnetic "north"|"south"|"sticky"|"repell"|nil if the drop is magnetic and which polarisation it has
+---@field burnTime number the tick where it will burn
 
 ---@class DropShape: Shape
 ---@field interactable DropInteractable
+
 -- #endregion

--- a/Scripts/Upgraders/FireUpgrader.lua
+++ b/Scripts/Upgraders/FireUpgrader.lua
@@ -16,7 +16,7 @@ end
 
 function FireUpgrader:sv_onUpgrade(shape, data)
     if g_drops[tostring(shape.uuid)].flammable then
-        data.burnTime = self.data.upgrade.burnTime
+        data.burnTime = sm.game.getCurrentTick() + self.data.upgrade.burnTime
         data.value = data.value + (self.data.upgrade.add or 0)
         data.value = data.value * (self.data.upgrade.multiplier or 1)
 
@@ -36,6 +36,6 @@ end
 ---@class FireUpgraderUpgrade : UpgraderUpgrade
 ---@field multiplier number|nil the multiplier to be applied during an upgrade
 ---@field add number|nil the amount added to a drop's value during an upgrade
----@field burnTime number how long the drop will burn until it is destroyed after upgrade
+---@field burnTime number amount of ticks the drop will burn until it is destroyed
 
 -- #endregion


### PR DESCRIPTION
Fix issue where putting a burning drop into a container would persist the burn time, thus removing the time requirement for burning drops.

there might be an issue when saving the world and loading again if gameTick is reset to 0 when loading.